### PR TITLE
Fix the `strings` mode correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,65 @@
 # Ember-cli-lazy-code
 
-This README outlines the details of collaborating on this Ember addon.
+This addon is an inspiration from Google's startup latency [blog](http://googlecode.blogspot.com/2009/09/gmail-for-mobile-html5-series-reducing.html).
+
+This addon converts the app file's AMD modules into a string equivalent format. It primarily is used to
+lazily evaluate AMD modules by converting into an Object literal format that can be JSON stringified.
+This is very useful on low powered devices where we want to lazily evaluate javascript and only evaluate Javascript that is needed in the initial load.
+
+Consider the following AMD modules:
+```javascript
+define('a', ['exports', 'b', 'c'], function(_exports, _a, _b) {
+  _exports.add = function add(n1, n2) {
+    return _a.default(n1) + _b.default(n2);
+  }
+});
+define('b', ['exports', 'c'], function(_exports, _c) {
+  _exports.default = function addOne(n) {
+    return _c.default(n) + 1;
+  }
+});
+define('c', ['exports'], function(_exports) {
+  _exports.default = function id(n) {
+    return n;
+  }
+});
+```
+
+With an AMD module there 3 parts of the signature:
+
+1. The module id `string`
+2. The modules dependencies ids `Array<string>`
+3. The anonymous function that executes the modules code. Called with the reified dependecies.
+
+With this addon, we write an AST transform that captures the call of the `define` and re-writes it into an Object literal structure that can be `JSON.stringify`ed.
+
+After the build, all app's AMD modules will be in this format by default:
+```javascript
+{
+  "a": {
+    "imports": ["exports", "b", "c"],
+    "arguments": ["_exports", "_b", "_c"],
+    "body": "_exports.add = function add(n1, n2) { return _a.default(n1) + _b.default(n2); }"
+  },
+  "b": {
+    "imports": ["exports", "c"],
+    "arguments": ["_exports", "_c"],
+    "body": "_exports.default = function addOne(n) { return _c.default(n) + 1; }"
+  },
+  "c": {
+    "imports": ["exports"],
+    "arguments": ["_exports"],
+    "body": "_exports.default = function id(n) { return n;}"
+  }
+}
+```
+
+There are also other modes that this addon functions in but currently it is only tested in `strings` mode.
+
+Since the format of the modules has been changed, we need to teach the [loader.js](https://github.com/kratiahuja/loader.js/blob/master/lib/loader/loader.js#L284) to recognize this new format.
+
+## Note
+When using this addon, please use [ember-cli-string-module-loader](https://github.com/kratiahuja/ember-cli-string-module-loader) addon instead of [loader.js](https://github.com/ember-cli/loader.js) addon.
 
 ## Installation
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,30 +28,53 @@ LazyCode.prototype.createPosition = function(start, end, wrapInIIFE, params) {
   };
 };
 
+LazyCode.prototype.getModuleInfo = function(node) {
+  var functionExpression = node.arguments[2];
+  var functionBody = functionExpression.body.body;
+
+  return {
+    moduleId: node.arguments[0].value,
+    imports: node.arguments[1].elements.map(function(el) { return el.value}),
+    params: functionExpression.params.map(function(id) { return id.name;}),
+    define: {
+      start: node.start,
+      end: node.end
+    },
+    body: {
+      start: functionBody[0].start,
+      end: functionBody[functionBody.length - 1].end
+    }
+  }
+};
+
+LazyCode.prototype.stringifyModule = function(node, options) {
+  if (node.type === 'CallExpression' && node.callee.name === 'define') {
+    options.modules.push(this.getModuleInfo(node));
+  }
+};
+
 LazyCode.prototype.traverseAndStringify = function(ast, options) {
-  traverse(ast, {
-    enter: function(path) {
-      if (path.node.type === 'CallExpression') {
-        if (path.node.callee.name === 'define') {
-          var functionExpression = path.node.arguments[2];
-          var functionBody = functionExpression.body.body;
-          options.modules.push({
-            moduleId: path.node.arguments[0].value,
-            imports: path.node.arguments[1].elements.map(function(el) { return el.value; }),
-            params: functionExpression.params.map(function(id) { return id.name; }),
-            define: {
-              start: path.node.start,
-              end: path.node.end
-            },
-            body: {
-              start: functionBody[0].start,
-              end: functionBody[functionBody.length - 1].end
-            }
-          });
+  var body = ast.program.body;
+
+  for (var i=0; i<body.length; i++) {
+    var parentNode = body[i];
+
+    if (parentNode.type === 'ExpressionStatement') {
+      var node = parentNode.expression;
+      if (node.type === 'SequenceExpression') {
+        // in prod mode, all the defines are under the sequence expression node
+        var seqExpressions = node.expressions;
+        for (var j=0; j<seqExpressions.length; j++) {
+          // loop through each sequence expression that contains a call expression
+          var seqExp = seqExpressions[j];
+          this.stringifyModule(seqExp, options);
         }
+      } else {
+        // in dev mode, each expression node is its own define
+        this.stringifyModule(node, options);
       }
     }
-  });
+  }
 };
 
 LazyCode.prototype.traverseAndWrap = function(ast, options) {
@@ -108,7 +131,9 @@ LazyCode.prototype.processString = function (content) {
 
 function stringify(modules, s) {
   var stringRegistry = {};
-  modules.forEach(function(mod) {
+  // default replacement if no AMD module is found
+  var replacementChar = 13;
+  modules.forEach(function(mod, index) {
     var defineStart = mod.define.start;
     var defineEnd = mod.define.end + 1;
     var bodyStart = mod.body.start;
@@ -118,20 +143,31 @@ function stringify(modules, s) {
     //   return '\'' + param + '\'';
     // });
 
-    stringRegistry[mod.moduleId] = {
+    stringRegistry[mod.moduleId] = JSON.stringify({
       imports: mod.imports,
       params: mod.params,
       body: moduleBody
-    };
+    });
 
+    if (index === 0) {
+      // this is the first AMD module being processed
+      // we need to replace all the AMD modules starting from here
+      replacementChar = defineStart;
+    }
     s.remove(defineStart, defineEnd);
   });
 
-  s.insert(13, '\nvar stringRegistry = ' + JSON.stringify(stringRegistry) + ';');
+  var previousChar = s.snip(replacementChar-1, replacementChar).toString();
+  if (previousChar === ',') {
+    // prod builds add ',' to after each block and compress the new lines
+    s.overwrite(replacementChar-1, replacementChar, ';');
+  }
+  // replace all AMD modules with their string equivalent representation to make v8 happy
+  s.insert(replacementChar, '\n var stringRegistry = ' + JSON.stringify(stringRegistry) + '; \ndefineStringModule(stringRegistry);');
 }
 
 function snipModuleBody(start, end, s) {
-  return JSON.stringify(s.snip(start, end).toString());
+  return s.snip(start, end).toString();
 }
 
 function wrap(mode, positions, s) {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "after": "ember-cli-uglify"
+    "after": "ember-cli-uglify",
+    "before": "broccoli-asset-rev"
   }
 }


### PR DESCRIPTION
This PR fixes a few things in this addon: 
- Runs the addon before broccoli-asset-rev so that file name is found before the fingerprinting
- Updates the README to correctly describe what this addon solves in depth
- `strings` mode fixes:
  - Do not stringify function body since we are stringifing the entire module already. This eliminates the need to do an eval in the loader.js
  - Fixes the stringRegistry replacement to correctly occur at the first define start character. This allows apps to use `app-prefix` and `app-boot` hooks and not replace those incorrectly.
  - Prod builds unifies all modules and the hooks data as comma seperated, therefore we need to replace the suffix comma with a semicolon
  - Do not traverse the ast tree recursively. Instead traverse in a BFS fashion only for the first level where the modules are defined.

TODO:
- [ ] Get list of initializers needed by ember-load-initializers addon during build time using the AST.
