### PR TITLE
Export app initializers and instance initializers as a seperate object during build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ After the build, all app's AMD modules will be in this format by default:
 }
 ```
 
-There are also other modes that this addon functions in but currently it is only tested in `strings` mode.
+This addon only supports the `strings` mode currently. In future, we may add variations to this.
 
 Since the format of the modules has been changed, we need to teach the [loader.js](https://github.com/kratiahuja/loader.js/blob/master/lib/loader/loader.js#L284) to recognize this new format.
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = {
   included: function(app) {
     this.app = app;
   },
+
   postprocessTree: function(type, tree) {
     if (type === 'all') {
       var appName = this.app.name;
@@ -18,6 +19,7 @@ module.exports = {
       var lazyApp = new LazyCode(app, {
         wrapInIIFE: [appName + '/config/environment'],
         mode: this.app.options.lazyCode && this.app.options.lazyCode.mode || 'strings',
+        appName: appName, // assuming appName is always same as config.modulePrefix
         description: 'ember-cli-lazy-code'
       });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,14 @@ var PersistentFilter = require('broccoli-persistent-filter');
 
 function LazyCode(node, options) {
   this.wrapInIIFE = options.wrapInIIFE;
+  this.appInitializerRegex = new RegExp('^' + options.appName + '\/((?:instance-)?initializers)\/');
   this.mode = options.mode;
+  if (this.mode !== 'strings') {
+    throw new Error('Mode' + this.mode + ' is not applicable for this addon.');
+  }
+  // default replacement character if none is found
+  this.replacementChar = 13;
+  this.isFirstDefineSeen = false;
   PersistentFilter.call(this, node, options);
 }
 
@@ -17,17 +24,6 @@ LazyCode.prototype.constructor = LazyCode;
 
 LazyCode.prototype.extensions = ['js'];
 LazyCode.prototype.targetExtension = 'js';
-
-LazyCode.prototype.createPosition = function(start, end, wrapInIIFE, params) {
-  return {
-    start: start,
-    end: end,
-    wrapInIIFE: wrapInIIFE,
-    arguments: params.map(function(identifier) {
-      return identifier.name;
-    })
-  };
-};
 
 LazyCode.prototype.getModuleInfo = function(node) {
   var functionExpression = node.arguments[2];
@@ -53,14 +49,49 @@ LazyCode.prototype.getModuleInfo = function(node) {
   }
 };
 
-LazyCode.prototype.stringifyModule = function(node, options) {
+LazyCode.prototype.addInitializerModule = function(moduleName, initializerModules) {
+  // logic is copied from ember-load-initializers and moved to build time to save user's time
+  var matches = this.appInitializerRegex.exec(moduleName);
+
+  if (matches && matches.length === 2) {
+    initializerModules.push({
+      moduleName: moduleName,
+      matches: matches
+    });
+  }
+}
+
+LazyCode.prototype.stringifyModule = function(node, options, stringRegistry, initializerModules) {
   if (node.type === 'CallExpression' && node.callee.name === 'define') {
-    options.modules.push(this.getModuleInfo(node));
+    var mod = this.getModuleInfo(node);
+    var defineStart = mod.define.start;
+    var defineEnd = mod.define.end + 1;
+    var bodyStart = mod.body.start;
+    var bodyEnd = mod.body.end;
+    var moduleBody = snipModuleBody(bodyStart, bodyEnd, options.s);
+
+    if (!this.isFirstDefineSeen) {
+      // this is the first AMD module seen, grab its start position for replacement
+      this.replacementChar = defineStart;
+      this.isFirstDefineSeen = true;
+    }
+
+    stringRegistry[mod.moduleId] = JSON.stringify({
+      imports: mod.imports,
+      params: mod.params,
+      body: moduleBody
+    });
+
+    this.addInitializerModule(mod.moduleId, initializerModules);
+
+    options.s.remove(defineStart, defineEnd);
   }
 };
 
 LazyCode.prototype.traverseAndStringify = function(ast, options) {
   var body = ast.program.body;
+  var stringRegistry = {};
+  var initializerModules = [];
 
   for (var i=0; i<body.length; i++) {
     var parentNode = body[i];
@@ -73,37 +104,26 @@ LazyCode.prototype.traverseAndStringify = function(ast, options) {
         for (var j=0; j<seqExpressions.length; j++) {
           // loop through each sequence expression that contains a call expression
           var seqExp = seqExpressions[j];
-          this.stringifyModule(seqExp, options);
+          this.stringifyModule(seqExp, options, stringRegistry, initializerModules);
         }
       } else {
         // in dev mode, each expression node is its own define
-        this.stringifyModule(node, options);
+        this.stringifyModule(node, options, stringRegistry, initializerModules);
       }
     }
   }
-};
 
-LazyCode.prototype.traverseAndWrap = function(ast, options) {
-  var self = this;
-  var positions = options.positions;
-
-  traverse(ast, {
-    enter: function(path) {
-      if (path.node.type === 'CallExpression') {
-        if (path.node.callee.name === 'define') {
-          var start = path.node.arguments[2].body.body[0].start;
-          var end = path.node.arguments[2].body.body[path.node.arguments[2].body.body.length - 1].end;
-          var moduleId = path.node.arguments[0].value;
-          var params = path.node.arguments[2].params;
-          if (self.wrapInIIFE.indexOf(moduleId) > -1) {
-            positions.push(self.createPosition(start, end, true, params));
-          } else {
-            positions.push(self.createPosition(start, end, false, params));
-          }
-        }
-      }
-    }
-  });
+  var previousChar = options.s.snip(this.replacementChar - 1, this.replacementChar).toString();
+  if (previousChar === ',') {
+    // prod builds add ',' to after each block and compress the new lines
+    options.s.overwrite(this.replacementChar - 1, this.replacementChar, ';');
+  }
+  // replace all AMD modules with their string equivalent representation to make v8 happy
+  var replacementString = '\nvar stringRegistry = ' + JSON.stringify(stringRegistry) + ';' +
+                          '\ndefineStringModule(stringRegistry);' +
+                          '\nvar initializerRegistry = ' + JSON.stringify(initializerModules) + ';' +
+                          '\ndefineInitializerRegistry(initializerRegistry);';
+  options.s.insert(this.replacementChar, replacementString);
 };
 
 LazyCode.prototype.processString = function (content) {
@@ -111,54 +131,14 @@ LazyCode.prototype.processString = function (content) {
     return content;
   }
   var ast = transform(content).ast;
-  var modules = [];
   var s = new MagicString(content);
-  var mode = this.mode;
 
-  if (mode === 'strings') {
-    this.traverseAndStringify(ast, {
-      modules: modules
-    });
-
-    stringify(modules, s);
-  }
+  this.traverseAndStringify(ast, {
+    s: s
+  });
 
   return s.toString();
 };
-
-function stringify(modules, s) {
-  var stringRegistry = {};
-  // default replacement if no AMD module is found
-  var replacementChar = 13;
-  modules.forEach(function(mod, index) {
-    var defineStart = mod.define.start;
-    var defineEnd = mod.define.end + 1;
-    var bodyStart = mod.body.start;
-    var bodyEnd = mod.body.end;
-    var moduleBody = snipModuleBody(bodyStart, bodyEnd, s);
-
-    stringRegistry[mod.moduleId] = JSON.stringify({
-      imports: mod.imports,
-      params: mod.params,
-      body: moduleBody
-    });
-
-    if (index === 0) {
-      // this is the first AMD module being processed
-      // we need to replace all the AMD modules starting from here
-      replacementChar = defineStart;
-    }
-    s.remove(defineStart, defineEnd);
-  });
-
-  var previousChar = s.snip(replacementChar-1, replacementChar).toString();
-  if (previousChar === ',') {
-    // prod builds add ',' to after each block and compress the new lines
-    s.overwrite(replacementChar-1, replacementChar, ';');
-  }
-  // replace all AMD modules with their string equivalent representation to make v8 happy
-  s.insert(replacementChar, '\n var stringRegistry = ' + JSON.stringify(stringRegistry) + '; \ndefineStringModule(stringRegistry);');
-}
 
 function snipModuleBody(start, end, s) {
   return s.snip(start, end).toString();


### PR DESCRIPTION
This PR addresses the following:
- Exposes an initializer registry that contains all the modules that are initializers and instance initializers for ember-load-initializers to walk less at run time
- Avoids walking all the modules twice during the build
- Cleans up unused functions
